### PR TITLE
Opendaq with findpkg redirect

### DIFF
--- a/dependencies/openDAQ/CMakeLists.txt
+++ b/dependencies/openDAQ/CMakeLists.txt
@@ -15,11 +15,7 @@ if(NOT IGNORE_INSTALLED_SDK)
     find_package(openDAQ QUIET GLOBAL)
 endif()
 
-if(openDAQ_FOUND)
-
-	include("${openDAQ_DIR}/../../../share/cmake/openDAQUtils.cmake")
-
-else()
+if(NOT openDAQ_FOUND)
 
 	if(NOT IGNORE_INSTALLED_SDK)
         message(WARNING

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,4 +46,3 @@ target_include_directories(${LIB_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_
 
 set(OPENDAQ_MODULE_SUFFIX ".module${CMAKE_SHARED_LIBRARY_SUFFIX}")
 opendaq_set_module_properties(${LIB_NAME} ${PROJECT_VERSION_MAJOR})
-create_version_header(${LIB_NAME})


### PR DESCRIPTION
See individual commits for details. These changes allow JetModule to work with preinstalled (non-fetched) SDKs.